### PR TITLE
Test that data type lexical form pass the data type check

### DIFF
--- a/modules/srdfJena/src/main/scala/es/weso/rdf/jena/JenaMapper.scala
+++ b/modules/srdfJena/src/main/scala/es/weso/rdf/jena/JenaMapper.scala
@@ -3,7 +3,7 @@ package es.weso.rdf.jena
 // TODO: Refactor this code
 import org.apache.jena.rdf.model.{AnonId, Literal, ModelFactory, Property, Resource, Statement, StmtIterator, Model => JenaModel, RDFNode => JenaRDFNode}
 import es.weso.rdf.nodes._
-import org.apache.jena.datatypes.BaseDatatype
+import org.apache.jena.datatypes.{BaseDatatype, TypeMapper}
 import org.apache.jena.datatypes.xsd.XSDDatatype
 import es.weso.rdf.triples.RDFTriple
 import es.weso.rdf.PREFIXES._
@@ -230,7 +230,8 @@ object JenaMapper {
     node match {
       case l: es.weso.rdf.nodes.Literal => {
         Try{
-          val jenaLiteral = emptyModel.createTypedLiteral(l.getLexicalForm,l.dataType.str)
+          val expectedRDFDatatype = TypeMapper.getInstance().getSafeTypeByName(expectedDatatype.str)
+          val jenaLiteral = emptyModel.createTypedLiteral(l.getLexicalForm,expectedRDFDatatype)
           val value = jenaLiteral.getValue() // if it is ill-typed it raises an exception
           (jenaLiteral.getDatatypeURI)
         } match {

--- a/modules/srdfJena/src/test/scala/es/weso/rdftriple/jenaMapper/JenaMapperTest.scala
+++ b/modules/srdfJena/src/test/scala/es/weso/rdftriple/jenaMapper/JenaMapperTest.scala
@@ -152,6 +152,13 @@ class JenaMapperTest
         case Right(node) => fail(s"Should fail but passed $node")
       }
     }
+    it("Should validate when checking dateTime lexical form with dateTime data type") {
+      val node = StringLiteral("2017-05-15T16:27:01-00:00")
+      wellTypedDatatype(node,IRI("http://www.w3.org/2001/XMLSchema#dateTime")) match {
+        case Left(e) => fail(s"Should pass but failed: $e")
+        case Right(node) => info(s"Passed as expected: $node")
+      }
+    }
 
     it("Should fail checking date with dateTime") {
       val node = DatatypeLiteral("2017-05-15", IRI("http://www.w3.org/2001/XMLSchema#date"))
@@ -160,7 +167,6 @@ class JenaMapperTest
         case Right(node) => fail(s"Should fail but passed $node")
       }
     }
-
 
   }
 


### PR DESCRIPTION
"All value nodes of a property must be subclasses of a specific root class."

Just to demo the idea.