### PR TITLE
Make logbackClassic a Test dep; replace most println's (#84)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -101,7 +101,7 @@ lazy val shaclex = project
   .settings(
     unidocProjectFilter in (ScalaUnidoc, unidoc) := inAnyProject -- inProjects(noDocProjects: _*),
     libraryDependencies ++= Seq(
-      logbackClassic,
+      logbackClassic % Test,
       scalaLogging,
       scallop
     ),
@@ -187,7 +187,7 @@ lazy val shex = project
   .settings(
     libraryDependencies ++= Seq(
       typesafeConfig % Test,
-      logbackClassic,
+      logbackClassic % Test,
       scalaLogging,
       circeCore,
       circeGeneric,
@@ -290,7 +290,7 @@ lazy val srdfJena = project
   .settings(commonSettings, publishSettings)
   .settings(
     libraryDependencies ++= Seq(
-      logbackClassic,
+      logbackClassic % Test,
       scalaLogging,
       typesafeConfig % Test,
       jenaArq,

--- a/build.sbt
+++ b/build.sbt
@@ -307,7 +307,7 @@ lazy val srdf4j = project
   .settings(commonSettings, publishSettings)
   .settings(
     libraryDependencies ++= Seq(
-      logbackClassic,
+      logbackClassic % Test,
       scalaLogging,
       typesafeConfig % Test,
       rdf4j_runtime,

--- a/modules/rbe/src/main/scala/es/weso/rbe/Rbe.scala
+++ b/modules/rbe/src/main/scala/es/weso/rbe/Rbe.scala
@@ -4,6 +4,7 @@ import es.weso.collection._
 import interval._
 import IntOrUnbounded._
 import cats._
+import com.typesafe.scalalogging.LazyLogging
 
 /**
  * This trait defines Single Occurrence Regular Bag Expressions (Rbe)
@@ -17,7 +18,7 @@ import cats._
  *     S. Staworko, I. Boneva, J. Labra, S. Hym, E. Prud'hommeaux, H. Solbrig
  *
  */
-sealed trait Rbe[+A] {
+sealed trait Rbe[+A] extends LazyLogging {
 
   /**
    * Checks if a RBE contains repetitions
@@ -94,7 +95,7 @@ sealed trait Rbe[+A] {
       case Repeat(_, 0, _) => true //
       case Repeat(e, _, _) => e.nullable
     }
-    println(s"$this nullable?: $r")
+    logger.debug(s"$this nullable?: $r")
     r
   }
 

--- a/modules/schema/src/main/scala/es/weso/schema/Result.scala
+++ b/modules/schema/src/main/scala/es/weso/schema/Result.scala
@@ -165,7 +165,7 @@ object Result extends LazyLogging {
   // TODO: implement this
   implicit val decodeTrigger: Decoder[Option[ValidationTrigger]] = Decoder.instance { c =>
     {
-      println("Trigger decoder not implemented")
+      logger.warn("Trigger decoder not implemented")
       ??? //Right(None)
     }
   }
@@ -173,7 +173,7 @@ object Result extends LazyLogging {
   // TODO: implement this
   implicit val decodePrefixMap: Decoder[PrefixMap] = Decoder.instance { c =>
     {
-      println("PrefixMap decoder not implemented")
+      logger.warn("PrefixMap decoder not implemented")
       ??? //Right(None)
     }
   }

--- a/modules/shacl/src/main/scala/es/weso/shacl/validator/Validator.scala
+++ b/modules/shacl/src/main/scala/es/weso/shacl/validator/Validator.scala
@@ -600,7 +600,7 @@ case class Validator(schema: Schema) extends LazyLogging {
       case n: DecimalLiteral => ok(n.decimal.toInt)
       case n: DoubleLiteral => ok(n.double.toInt)
       case DatatypeLiteral(str,`xsd_integer`) => {
-        println(s"Integer! str: $str")
+        logger.debug(s"Integer! str: $str")
         ok(Integer.parseInt(str))
       }
       case _ => err(notNumeric(node, attempt)) *> ok(0)

--- a/modules/shex/src/main/scala/es/weso/shex/compact/DebugSchemaMaker.scala
+++ b/modules/shex/src/main/scala/es/weso/shex/compact/DebugSchemaMaker.scala
@@ -11,7 +11,7 @@ import es.weso.shex.parser.ShExDocParser.ShExDocContext
 class DebugSchemaMaker extends ShExDocBaseVisitor[Any] with LazyLogging {
 
   override def visitShExDoc(ctx: ShExDocContext): Builder[Schema] = {
-    println("Visiting ShExDoc")
+    logger.debug("Visiting ShExDoc")
     visitChildren(ctx)
     ok(Schema.empty)
   }

--- a/modules/shex/src/main/scala/es/weso/shex/compact/Parser.scala
+++ b/modules/shex/src/main/scala/es/weso/shex/compact/Parser.scala
@@ -90,12 +90,12 @@ object Parser extends LazyLogging {
     val UTF8_BOM = "\uFEFF"
     val s =
       if (str.startsWith(UTF8_BOM)) {
-        println("BOM detected and removed")
+        logger.info("BOM detected and removed")
         str.substring(1)
       } else str
     val reader: JavaReader =
       new InputStreamReader(new ByteArrayInputStream(s.getBytes(StandardCharsets.UTF_8)))
-    println(s"s:$s")
+    logger.debug(s"s:$s")
     parseSchemaReader(reader, base)
   }
 

--- a/modules/srdf/src/main/scala/es/weso/rdf/PrefixMap.scala
+++ b/modules/srdf/src/main/scala/es/weso/rdf/PrefixMap.scala
@@ -30,7 +30,7 @@ case class PrefixMap(pm: Map[Prefix, IRI]) extends LazyLogging {
       case n => {
         val (alias, colonLocalname) = str.splitAt(n)
         val localname = colonLocalname.drop(1)
-        println(s"Alias: '$alias', localName: '$localname'")
+        logger.debug(s"Alias: '$alias', localName: '$localname'")
         getIRI(alias).map(iri => iri.add(localname))
       }
     }


### PR DESCRIPTION
Most of the `println` statements outside the test code and outside the
server module were replaced with logger calls.

`logbackClassic` was switched to a `Test` dependency so that it won't
conflict with the users' choice of the SLF4J backend later in their
apps.

